### PR TITLE
Prevent file content in ansible output 

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -18,3 +18,5 @@
     group: "{{ item.group | default(aux_file_default_group) }}"
     mode: "{{ item.mode | default(aux_file_default_mode) }}"
   with_items: "{{ aux_file_definitions }}"
+  loop_control:
+    label: "{{ item.dest }}"


### PR DESCRIPTION
Prevent file content in ansible output by only showing the destination path in the Ansible output. This solves issue #1 .

**Before**:
`TASK [galaxy/aux : Ensure AUX files are created] ***********************************************************************
ok: [mash_server_test] => (item={'dest': '/mash/traefik/config/test.file', 'content': 'this is some top secret stuff\n'})`

**After:**
`TASK [galaxy/aux : Ensure AUX files are created] ***********************************************************************
ok: [mash_server_test] => (item=/mash/traefik/config/test.file)`

